### PR TITLE
Make grep-notify behave like regular grep, and fix Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ LIBS = $(shell pkg-config --libs --cflags libnotify)
 SRC = grep-notify.c
 
 all:
-	gcc -o grep-notify $(LIBS) $(SRC)
+	gcc -o grep-notify $(SRC) $(LIBS)
 
 clean:
 	rm -rf *o grep-notify

--- a/grep-notify.c
+++ b/grep-notify.c
@@ -34,10 +34,9 @@ int main(int argc, char **argv) {
 
 	while (getline(&line, &size, stdin) != -1) {
 		if (!regexec(&regex, line, 0, NULL, 0)) {
+			fprintf(stdout, line);
 			notify(line);
 		}
-
-		fprintf(stdout, line);
 	}
 
 	free(line);


### PR DESCRIPTION
Hi,

This PR fixes the Makefile (`$(LIBS)` should come after everything in the command line) and also makes the command-line output behave like grep